### PR TITLE
add windows support

### DIFF
--- a/HyperMake
+++ b/HyperMake
@@ -54,6 +54,16 @@ targets:
         cmds:
             - ./build.sh darwin amd64
 
+    hmake-windows-amd64:
+        description: static linked hmake binary for Windows
+        after:
+            - generate
+        watches:
+            - '**/**/*.go'
+            - build.sh
+        cmds:
+            - ./build.sh windows amd64
+
     test:
         description: run tests
         after:
@@ -90,6 +100,7 @@ targets:
         after:
             - hmake-linux-amd64
             - hmake-darwin-amd64
+            - hmake-windows-amd64
 
 settings:
     default-targets:

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Install
 - [gomega](https://github.com/onsi/gomega)
 
 ```bash
-go get https://github.com/FiloSottile/gvt
-go get https://github.com/onsi/ginkgo/ginkgo
-go get https://github.com/onsi/gomega
+go get github.com/FiloSottile/gvt
+go get github.com/onsi/ginkgo/ginkgo
+go get github.com/onsi/gomega
 gvt restore
 ginkgo test ./test
 # or
@@ -408,6 +408,7 @@ hmake [OPTIONS] [TARGETS]
 - docker 1.9 and above (1.9 - 1.11 tested)
 - Linux (Ubuntu 14.04 tested)
 - Mac OS X 10.9 and above (10.9, 10.11 tested)
+- Windows 7 SP1
 
 ## Known issues
 

--- a/docker/docker-darwin.go
+++ b/docker/docker-darwin.go
@@ -2,59 +2,19 @@
 
 package docker
 
-import (
-	"fmt"
-	"os"
-	"os/exec"
-	"strconv"
-	"strings"
-)
+func (r *Runner) checkProjectDir() error {
+	return nil
+}
 
-var (
-	errDockerMachineUnknown = fmt.Errorf("unknown DOCKER_MACHINE_NAME")
-)
+func (r *Runner) canonicalProjectDir() string{
+	return r.projectDir
+}
 
 func (r *Runner) exposeDocker() {
 	r.exposeDockerEnv()
 }
 
-func inspectIds(opt string) (ids []int, err error) {
-	machine := os.Getenv("DOCKER_MACHINE_NAME")
-	if machine == "" {
-		return ids, errDockerMachineUnknown
-	}
-
-	args := []string{"docker-machine", "ssh", machine, "id", opt}
-	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Env = os.Environ()
-	out, err := cmd.Output()
-	if err != nil {
-		return ids, fmt.Errorf("error: [%s]: %v", strings.Join(args, " "), err)
-	}
-	tokens := strings.Split(string(out), " ")
-	for _, token := range tokens {
-		if i, err := strconv.Atoi(strings.TrimSpace(token)); err == nil {
-			ids = append(ids, i)
-		}
-	}
-	if len(ids) == 0 {
-		return ids, fmt.Errorf("no id found: [%s]", strings.Join(args, " "))
-	}
-	return
-}
-
 func currentUserIds() (uid, gid int, grps []int, err error) {
-	var uids, gids []int
-	if uids, err = inspectIds("-u"); err != nil {
-		return
-	}
-	uid = uids[0]
-	if gids, err = inspectIds("-g"); err != nil {
-		return
-	}
-	gid = gids[0]
-	if grps, err = inspectIds("-G"); err != nil {
-		return
-	}
+	uid, gid, grps, err = currentUserIdsFromDockerMachine()
 	return
 }

--- a/docker/docker-linux.go
+++ b/docker/docker-linux.go
@@ -8,6 +8,14 @@ const (
 	dockerSockPath = "/var/run/docker.sock"
 )
 
+func (r *Runner) checkProjectDir() error {
+	return nil
+}
+
+func (r *Runner) canonicalProjectDir() string {
+	return r.projectDir
+}
+
 func (r *Runner) exposeDocker() {
 	r.exposeDockerEnv()
 	if os.Getenv("DOCKER_HOST") == "" {

--- a/docker/docker-machine.go
+++ b/docker/docker-machine.go
@@ -1,0 +1,55 @@
+package docker
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+var (
+	errDockerMachineUnknown = fmt.Errorf("unknown DOCKER_MACHINE_NAME")
+)
+
+func inspectIds(opt string) (ids []int, err error) {
+	machine := os.Getenv("DOCKER_MACHINE_NAME")
+	if machine == "" {
+		return ids, errDockerMachineUnknown
+	}
+
+	args := []string{"docker-machine", "ssh", machine, "id", opt}
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Env = os.Environ()
+	out, err := cmd.Output()
+	if err != nil {
+		return ids, fmt.Errorf("error: [%s]: %v", strings.Join(args, " "), err)
+	}
+	tokens := strings.Split(string(out), " ")
+	for _, token := range tokens {
+		if i, err := strconv.Atoi(strings.TrimSpace(token)); err == nil {
+			ids = append(ids, i)
+		}
+	}
+	if len(ids) == 0 {
+		return ids, fmt.Errorf("no id found: [%s]", strings.Join(args, " "))
+	}
+	return
+}
+
+func currentUserIdsFromDockerMachine() (uid, gid int, grps []int, err error) {
+	var uids, gids []int
+	if uids, err = inspectIds("-u"); err != nil {
+		return
+	}
+	uid = uids[0]
+	if gids, err = inspectIds("-g"); err != nil {
+		return
+	}
+	gid = gids[0]
+	if grps, err = inspectIds("-G"); err != nil {
+		return
+	}
+	return
+}
+

--- a/docker/docker-windows.go
+++ b/docker/docker-windows.go
@@ -1,0 +1,37 @@
+// +build windows
+
+package docker
+
+import (
+    "fmt"
+    "strings"
+    "path/filepath"
+)
+
+func parseWindowsPath(path string) string {
+    var slashedPath = filepath.ToSlash(path)
+    var subPaths = strings.Split(slashedPath, ":")
+    return fmt.Sprintf("/%v%v", strings.ToLower(subPaths[0]), subPaths[1])
+}
+
+func (r *Runner) checkProjectDir() error {
+	if !strings.HasPrefix(r.projectDir, "C:\\Users\\") {
+        return fmt.Errorf("The project path must be prefixed with C:\\Users\\ on Windows")
+    }
+
+    return nil
+}
+
+func (r *Runner) canonicalProjectDir() string {
+    return parseWindowsPath(r.projectDir)
+}
+
+func (r *Runner) exposeDocker() {
+	r.exposeDockerEnv()
+}
+
+func currentUserIds() (uid, gid int, grps []int, err error) {
+	uid, gid, grps, err = currentUserIdsFromDockerMachine()
+	return
+}
+


### PR DESCRIPTION
This patch is still in progress. Some of the methods should be refactored, but this change set will make hmake working on Windows 7.

For some scripts (e.g. `build.sh`) that would be used directly in docker container, please make sure the line endings is `LF`(\n), the `CRLF`(\r\n). The inside /bin/sh does not recognize the CRLF endings.

Refer to this [doc](https://help.github.com/articles/dealing-with-line-endings/) for more information.
