### PR TITLE
unify with/without docker-machine #49, #50

### DIFF
--- a/docker/docker-darwin.go
+++ b/docker/docker-darwin.go
@@ -2,7 +2,16 @@
 
 package docker
 
+import (
+	"fmt"
+	"strings"
+)
+
 func (r *Runner) checkProjectDir() error {
+	if !strings.HasPrefix(r.projectDir, "/Users/") {
+		return fmt.Errorf("The project path must be prefixed with /Users/ on Mac OS")
+	}
+
 	return nil
 }
 
@@ -12,12 +21,4 @@ func (r *Runner) canonicalProjectDir() string {
 
 func (r *Runner) exposeDocker() {
 	r.exposeDockerEnv()
-}
-
-func currentUserIds() (uid, gid int, grps []int, err error) {
-	return currentUserIdsFromDockerMachine()
-}
-
-func userID(name string) (uid, gid int, err error) {
-	return userIDFromDockerMachine(name)
 }

--- a/docker/docker-linux.go
+++ b/docker/docker-linux.go
@@ -2,11 +2,7 @@
 
 package docker
 
-import (
-	"os"
-	"os/user"
-	"strconv"
-)
+import "os"
 
 const (
 	dockerSockPath = "/var/run/docker.sock"
@@ -32,27 +28,4 @@ func (r *Runner) exposeDocker() {
 		}
 		r.Volumes = append(r.Volumes, sockPath+":"+sockPath)
 	}
-}
-
-func currentUserIds() (uid, gid int, grps []int, err error) {
-	uid = os.Getuid()
-	gid = os.Getgid()
-	grps, err = os.Getgroups()
-	return
-}
-
-func userID(name string) (uid, gid int, err error) {
-	var u *user.User
-	if uid, err = strconv.Atoi(name); err == nil {
-		u, err = user.LookupId(name)
-	} else {
-		u, err = user.Lookup(name)
-	}
-	if err == nil {
-		uid, err = strconv.Atoi(u.Uid)
-		if err == nil {
-			gid, err = strconv.Atoi(u.Gid)
-		}
-	}
-	return
 }

--- a/docker/docker-machine.go
+++ b/docker/docker-machine.go
@@ -12,6 +12,10 @@ var (
 	errDockerMachineUnknown = fmt.Errorf("unknown DOCKER_MACHINE_NAME")
 )
 
+func usingDockerMachine() bool {
+	return os.Getenv("DOCKER_MACHINE_NAME") != "" && os.Getenv("DOCKER_HOST") != ""
+}
+
 func inspectIds(opt, name string) (ids []int, err error) {
 	machine := os.Getenv("DOCKER_MACHINE_NAME")
 	if machine == "" {

--- a/docker/docker-windows.go
+++ b/docker/docker-windows.go
@@ -29,11 +29,3 @@ func (r *Runner) canonicalProjectDir() string {
 func (r *Runner) exposeDocker() {
 	r.exposeDockerEnv()
 }
-
-func currentUserIds() (uid, gid int, grps []int, err error) {
-	return currentUserIdsFromDockerMachine()
-}
-
-func userID(name string) (uid, gid int, err error) {
-	return userIDFromDockerMachine(name)
-}


### PR DESCRIPTION
Use the unified logic for all platforms when docker-machine is
in use or not.

This refactoring potentially fix the issues with Docker for
Mac/Windows.
