### PR TITLE
target digest includes target definition, resolve #51

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 language: go
 go:
-    - 1.6
+    - 1.7
     - tip
 
 services:
@@ -10,15 +10,15 @@ services:
 
 env:
     global:
-        - DOCKER_VERSION=1.10.1-0~trusty
+        - DOCKER_VERSION=1.12.1-0~trusty
 
 before_install:
     - apt-cache madison docker-engine
-    - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
+    - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y --force-yes docker-engine=${DOCKER_VERSION}
 
 script:
     - docker version
     - go get
     - go build
     - ./hmake all
-    - ./bin/hmake-*-linux-amd64 check test e2e site -sv
+    - ./bin/linux/amd64/hmake check test e2e site -sv

--- a/HyperMake
+++ b/HyperMake
@@ -21,48 +21,75 @@ targets:
         cmds:
             - gvt restore
 
-    generate:
-        description: generate source code
-        after:
-            - vendor
-        watches:
-            - build.sh
-        env:
-            - HMAKE_VER_SUFFIX
-            - HMAKE_RELEASE
-        cmds:
-            - mkdir -p bin
-            - ./build.sh genver
-
     hmake-linux-amd64:
         description: static linked hmake binary for Linux AMD64
         after:
-            - generate
+            - vendor
         watches:
             - '**/**/*.go'
             - build.sh
         cmds:
             - ./build.sh linux amd64
+        artifacts:
+            - bin/linux/amd64/hmake
+            - bin/hmake-linux-amd64.tar.gz
+            - bin/hmake-linux-amd64.tar.gz.sha256sum
+
+    hmake-linux-arm:
+        description: static linked hmake binary for Linux ARM v7
+        after:
+            - vendor
+        watches:
+            - '**/**/*.go'
+            - build.sh
+        cmds:
+            - GOARM=7 ./build.sh linux arm
+        artifacts:
+            - bin/linux/arm/hmake
+            - bin/hmake-linux-arm.tar.gz
+            - bin/hmake-linux-arm.tar.gz.sha256sum
+
+    hmake-linux-arm64:
+        description: static linked hmake binary for Linux ARM v8 (aarch64)
+        after:
+            - vendor
+        watches:
+            - '**/**/*.go'
+            - build.sh
+        cmds:
+            - ./build.sh linux arm64
+        artifacts:
+            - bin/linux/arm64/hmake
+            - bin/hmake-linux-arm64.tar.gz
+            - bin/hmake-linux-arm64.tar.gz.sha256sum
 
     hmake-darwin-amd64:
         description: static linked hmake binary for Mac OS
         after:
-            - generate
+            - vendor
         watches:
             - '**/**/*.go'
             - build.sh
         cmds:
             - ./build.sh darwin amd64
+        artifacts:
+            - bin/darwin/amd64/hmake
+            - bin/hmake-darwin-amd64.tar.gz
+            - bin/hmake-darwin-amd64.tar.gz.sha256sum
 
     hmake-windows-amd64:
         description: static linked hmake binary for Windows
         after:
-            - generate
+            - vendor
         watches:
             - '**/**/*.go'
             - build.sh
         cmds:
             - ./build.sh windows amd64
+        artifacts:
+            - bin/windows/amd64/hmake.exe
+            - bin/hmake-windows-amd64.zip
+            - bin/hmake-windows-amd64.zip.sha256sum
 
     site:
         description: generate document site
@@ -132,9 +159,7 @@ targets:
     all:
         description: the default make target
         after:
-            - hmake-linux-amd64
-            - hmake-darwin-amd64
-            - hmake-windows-amd64
+            - 'hmake-*'
 
 settings:
     default-targets:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ brew install hmake
 Alternatively, download from Github [releases](https://github.com/evo-cloud/hmake/releases)
 
 ```
-curl -s https://github.com/evo-cloud/hmake/releases/download/v1.0.0/hmake-linux-amd64.tar.gz | sudo tar -C /usr/local/bin -zx
+curl -s https://github.com/evo-cloud/hmake/releases/download/v1.1.0rc2/hmake-linux-amd64.tar.gz | sudo tar -C /usr/local/bin -zx
 chmod a+rx /usr/local/bin/hmake
 ```
 
@@ -128,6 +128,7 @@ Please read the following documents if more detailed information is needed
 - Examples are always helpful
   - [Cross Compile Linux kernel](examples/linux/README.md)
   - [Cross Compile drone](examples/drone/README.md)
+- [FAQ and Best Practices](docs/FAQ.md)
 
 ## Supported Platform and Software
 
@@ -144,6 +145,12 @@ Please read the following documents if more detailed information is needed
 - `docker-machine` is not supported on Linux;
 
 See [Docker Driver](docs/DockerDriver.md) for details.
+
+#### Issues
+
+If you meet any issues or have specific problems, please check
+[FAQ and Best Practices](docs/FAQ.md) if there's already a solution.
+Feel free to email the maintainers for any questions.
 
 ## License
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6-alpine
+FROM golang:1.7-alpine
 RUN apk update && apk add curl git tar zip && rm -fr /var/cache/apk/* && \
     curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.10.0.tgz | tar -C / -xz && \
     go get -v github.com/alecthomas/gometalinter && \

--- a/docs/CommandLine.md
+++ b/docs/CommandLine.md
@@ -35,11 +35,13 @@ Common Unix command line option parsing rule is adopted:
 ## Options
 
 - `--chdir=PATH, -C PATH`: Chdir to specified PATH first before doing anything
+- `--file=FILE, -f FILE`: Override the default project file name `HyperMake`
 - `--include=FILE, -I FILE`: Include additional files (must be relative path under project root), can be specified multiple times
-- `--define=key=value, -D key=value`: Define property in global `settings` section, `key` may include `.` to specify the hierarchy
+- `--property=key=value, -P key=value`: Define property in global `settings` section, `key` may include `.` to specify the hierarchy
 - `--parallel=N, -p N`: Set maximum number of targets executed in parallel, 0 for auto, -1 for unlimited
 - `--rebuild-all, -R`: Force rebuild all needed targets
-- `--rebuild TARGET, -r TARGET`: Force rebuild specified target, this can repeat
+- `--rebuild-target TARGET, -r TARGET`: Force rebuild specified target, this can repeat
+- `--rebuild, -b`: Force rebuild targets specified on command line
 - `--skip TARGET, -S TARGET`: Skip specified target (mark as Skipped), this can repeat
 - `--json`: Dump execution events to stdout each encoded in single line json
 - `--summary, -s`: Show execution summary before exit

--- a/docs/DockerDriver.md
+++ b/docs/DockerDriver.md
@@ -87,15 +87,15 @@ docker container.
 
 - `tags`: a list of tags in addition to `image` when do `docker build`;
 
-- `commit`: commit running container into new image. Support multiple tags. 
-  Image tag will be 'latest', if not self-defined in image name. E.g.
+- `commit`: commit running container into new image. Support multiple tags.
+  Image tag will be `latest`, if not self-defined in image name. E.g.
 
   ```yaml
   target:
       image: new-image-name:newtag
       cmds:
           <Some commands>
-      commit: 
+      commit:
             - new-image-name:tag1
             - new-image-name:tag2
   ```
@@ -112,7 +112,7 @@ docker container.
 - `privileged`: run container in privileged mode, default is `false`;
 - `net`: when specified, only allowed value is `host`, when specified, run
   container with `--net=host --uts=host`;
-- `user`: passed to `docker run --user...`, by default, current `uid:gid` are 
+- `user`: passed to `docker run --user...`, by default, current `uid:gid` are
   passed (with _docker-machine_ the `uid:gid` is queried from the virtual machine
   running docker daemon).
   It must be explicitly specified `root` if the script is executed as root

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,41 @@
+# Questions and Best Practices
+
+- **Q**: Why I can't `git clone` private repositories?
+  **A**: HyperMake runs the build inside containers which may not have the right
+  SSH keys or credentials. There're two options:
+
+  - Mapping `~/.ssh` into the container using `volumes` property:
+
+    ```yaml
+    volumes:
+      - '~/.ssh:/src/.ssh:ro'
+    ```
+  - Mapping `~/.netrc` into the container:
+
+    first, create a file `~/.netrc`. See the
+    [manual](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html)
+    for the format and content. E.g.
+
+    ```
+    machine github.com
+    protocol https
+    login username
+    password password
+    ```
+
+    Then use `volumes` property to map into the container.
+
+    ```yaml
+    volumes:
+      - '~/.netrc:/src/.netrc:ro'
+    ```
+
+- **Q**: Can I build projects for Windows?<br>
+  **A**: Depending on toolchain. HyperMake builds on Linux, for C/C++,
+ install [mingw](http://www.mingw.org) toolchain in the container and do
+ the cross complication.
+
+- **Q**: Can I build projects for native Mac OS?<br>
+  **A**: Depending. If it's a project in Go, yes. If it depends on native Mac OS
+  libraries, it's possible when cross compiling toolchain and libraries are
+  installed on Linux.

--- a/hmake-cli.go
+++ b/hmake-cli.go
@@ -15,6 +15,13 @@ func cliDef() *flag.CliDef {
 					Tags:  map[string]interface{}{"help-var": "PATH"},
 				},
 				&flag.Option{
+					Name:  "file",
+					Alias: []string{"f"},
+					Desc:  "Specify the project filename instead of default HyperMake",
+					Tags:  map[string]interface{}{"help-var": "FILE"},
+					Type:  "string",
+				},
+				&flag.Option{
 					Name:    "include",
 					Alias:   []string{"I"},
 					Desc:    "Include additional files inside project directory, relative path",
@@ -23,10 +30,10 @@ func cliDef() *flag.CliDef {
 					Tags:    map[string]interface{}{"help-var": "FILE"},
 				},
 				&flag.Option{
-					Name:    "define",
-					Alias:   []string{"D"},
-					Desc:    "Define additional settings",
-					Example: "--define docker.src-volume=/tmp/src -D docker.image=myimage",
+					Name:    "property",
+					Alias:   []string{"P"},
+					Desc:    "Define additional setting property",
+					Example: "--property docker.src-volume=/tmp/src -P docker.image=myimage",
 					Type:    "dict",
 					Tags:    map[string]interface{}{"help-var": "KEY=VAL"},
 				},
@@ -46,11 +53,17 @@ func cliDef() *flag.CliDef {
 					Type:  "bool",
 				},
 				&flag.Option{
-					Name:  "rebuild",
+					Name:  "rebuild-target",
 					Alias: []string{"r"},
 					Desc:  "Rebuild specified targets",
 					List:  true,
 					Tags:  map[string]interface{}{"help-var": "TARGET"},
+				},
+				&flag.Option{
+					Name:  "rebuild",
+					Alias: []string{"b"},
+					Desc:  "Rebuild targets specified on command line",
+					Type:  "bool",
 				},
 				&flag.Option{
 					Name:  "skip",

--- a/hmake-ver.go
+++ b/hmake-ver.go
@@ -1,6 +1,0 @@
-// +build !genver
-
-package main
-
-// VersionSuffix of hmake
-const VersionSuffix = "-dev"

--- a/project/project.go
+++ b/project/project.go
@@ -16,8 +16,6 @@ import (
 const (
 	// Format is the supported format
 	Format = "hypermake.v0"
-	// RootFile is hmake filename sits on root
-	RootFile = "HyperMake"
 	// RcFile is the filename of local setting file to override some settings
 	RcFile = ".hmakerc"
 	// WorkFolder is the name of project WorkFolder
@@ -28,8 +26,13 @@ const (
 	LogFileName = "hmake.debug.log"
 )
 
-// ErrUnsupportedFormat indicates the file is not recognized
-var ErrUnsupportedFormat = fmt.Errorf("unsupported format")
+var (
+	// RootFile is hmake filename sits on root
+	RootFile = "HyperMake"
+
+	// ErrUnsupportedFormat indicates the file is not recognized
+	ErrUnsupportedFormat = fmt.Errorf("unsupported format")
+)
 
 // File defines the content of HyperMake or .hmake file
 type File struct {
@@ -140,7 +143,7 @@ func LoadFile(baseDir, path string) (*File, error) {
 }
 
 // LocateProjectFrom creates a project by locating the root file from startDir
-func LocateProjectFrom(startDir string) (*Project, error) {
+func LocateProjectFrom(startDir, projectFile string) (*Project, error) {
 	wd, err := filepath.Abs(startDir)
 	if err != nil {
 		return nil, err
@@ -149,7 +152,7 @@ func LocateProjectFrom(startDir string) (*Project, error) {
 
 	for {
 		p := &Project{BaseDir: wd, LaunchPath: launchPath}
-		_, err := p.Load(RootFile)
+		_, err := p.Load(projectFile)
 		if err == nil {
 			return p, nil
 		}
@@ -173,12 +176,12 @@ func LocateProject() (*Project, error) {
 	if err != nil {
 		return nil, err
 	}
-	return LocateProjectFrom(wd)
+	return LocateProjectFrom(wd, RootFile)
 }
 
 // LoadProjectFrom locates, resolves and finalizes project from startDir
-func LoadProjectFrom(startDir string) (p *Project, err error) {
-	if p, err = LocateProjectFrom(startDir); err != nil {
+func LoadProjectFrom(startDir, projectFile string) (p *Project, err error) {
+	if p, err = LocateProjectFrom(startDir, projectFile); err != nil {
 		return
 	}
 	if err = p.Resolve(); err != nil {
@@ -194,7 +197,7 @@ func LoadProject() (p *Project, err error) {
 	if err != nil {
 		return nil, err
 	}
-	return LoadProjectFrom(wd)
+	return LoadProjectFrom(wd, RootFile)
 }
 
 // RelPath translate a source relative path to project relative path

--- a/project/target.go
+++ b/project/target.go
@@ -1,8 +1,6 @@
 package project
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +23,7 @@ type Target struct {
 	WorkDir    string                 `json:"workdir"`
 	Watches    []string               `json:"watches"`
 	Always     bool                   `json:"always"`
+	Artifacts  []string               `json:"artifacts"`
 	Ext        map[string]interface{} `json:"*"`
 
 	// Runtime fields
@@ -62,7 +61,10 @@ func (t *Target) Initialize(name string, project *Project) {
 
 // IsTransit indicates the targets doesn't have actual work to do
 func (t *Target) IsTransit() bool {
-	return t.ExecDriver == "" && len(t.Ext) == 0 && len(t.Watches) == 0
+	return t.ExecDriver == "" &&
+		len(t.Ext) == 0 &&
+		len(t.Watches) == 0 &&
+		len(t.Artifacts) == 0
 }
 
 // GetExt maps Ext to provided value
@@ -364,13 +366,4 @@ func (w WatchList) String() string {
 		str += fmt.Sprintf("%s %d\n", item.Path, item.ModTime.Unix())
 	}
 	return str
-}
-
-// Digest calculates the digest based watched items
-func (w WatchList) Digest() string {
-	if w.IsEmpty() {
-		return ""
-	}
-	h := sha1.Sum([]byte(w.String()))
-	return hex.EncodeToString(h[0:])
 }

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -220,11 +220,17 @@ func (r *Runner) Run(sigCh <-chan os.Signal) (hm.TaskResult, error) {
 	return hm.Success, nil
 }
 
+// Signature implements Runner
+func (r *Runner) Signature() string {
+	return BuildScript(r.Task)
+}
+
+// ValidateArtifacts implements Runner
+func (r *Runner) ValidateArtifacts() bool {
+	return true
+}
+
 // Factory is runner factory
 func Factory(task *hm.Task) (hm.Runner, error) {
 	return &Runner{Task: task}, nil
-}
-
-func init() {
-	hm.RegisterExecDriver(ExecDriverName, Factory)
 }

--- a/test/e2e/suite.go
+++ b/test/e2e/suite.go
@@ -87,6 +87,10 @@ var _ = Describe("docker", func() {
 		wd, err := os.Getwd()
 		Expect(err).Should(Succeed())
 		exec.Command("docker", "rmi", "hmake-test-commit:newtag", "hmake-test-commit:tag2").Run()
+		// clean up
+		defer func() {
+			exec.Command("docker", "rmi", "hmake-test-commit:newtag", "hmake-test-commit:tag2").Run()
+		}()
 		cmd := exec.Command(pathToHmake, "-C", filepath.Join(wd, "docker-commit"), "test", "-vR")
 		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 		Expect(err).Should(Succeed())

--- a/test/fixtures/artifacts/HyperMake
+++ b/test/fixtures/artifacts/HyperMake
@@ -1,0 +1,13 @@
+---
+format: hypermake.v0
+
+name: artifacts
+
+targets:
+  t0:
+    touch: test.log
+    artifacts:
+      - test.log
+  t2:
+    artifacts:
+      - test2.log

--- a/test/fixtures/exec-order/HyperMake
+++ b/test/fixtures/exec-order/HyperMake
@@ -1,0 +1,38 @@
+---
+format: hypermake.v0
+
+name: exec-order
+
+targets:
+  t0:
+    watches:
+      - HyperMake
+      - '*.log'
+  t1.0:
+    after: [t0]
+    watches:
+      - HyperMake
+  t1.1:
+    after: [t0]
+    watches:
+      - HyperMake
+  t2:
+    after: [t1.0, t1.1]
+    cmds:
+      - 'echo -n hello'
+  t3.0:
+    after: [t2]
+    script: '#!/usr/bin/interpreter'
+  t3.1:
+    after: [t2]
+    do: something
+  t3.2:
+    after: [t2]
+    do: something
+  t3.3:
+    after: [t2]
+    do: something
+  all:
+    after:
+      - 't3*'
+    do: something

--- a/test/fixtures/task-change/HyperMake
+++ b/test/fixtures/task-change/HyperMake
@@ -1,0 +1,17 @@
+---
+format: hypermake.v0
+
+name: task-change
+
+targets:
+  t0:
+    do: something
+  t1:
+    do: something
+  t2:
+    after:
+      - t0
+      - t1
+  all:
+    after:
+      - t2

--- a/test/fixtures/task-change/HyperMake.changed
+++ b/test/fixtures/task-change/HyperMake.changed
@@ -1,0 +1,17 @@
+---
+format: hypermake.v0
+
+name: task-change
+
+targets:
+  t0:
+    do: something-new
+  all:
+    after:
+      - t1
+      - t2
+  t1:
+    do: something
+  t2:
+    after:
+      - t0


### PR DESCRIPTION
target definition in HyperMake is also calculated in digest;
add artifacts validation before/after target execution;
document update;
build with go1.7;

command-line changes:
- rename --define/-D to --property/-P
- rename --rebuild to --rebuild-target
- add --rebuild/-b to force rebuild targets on command-line
- add --file/-f to override default project filename
